### PR TITLE
Modularize tasks so they can be installed in projects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Fourk gulp
+A collection of useful gulp tasks.
+
+## How to use it
+* `npm i --save-dev fourkitchens/fourk-gulp`
+  * This will install the `master` branch. Please add `#tag/branchname` at the end if you need a certain branch/tag.
+* Add the following to your project's gulp file. This will pass gulp and config along to the newly installed tasks.
+```
+const gulp = require('gulp-help')(require('gulp'));
+const _ = require('lodash');
+let config = require('./gulp-config');
+let localConfig = {};
+
+try {
+  localConfig = require('./local.gulp-config');
+}
+catch (e) {}
+
+config = _.defaultsDeep(localConfig, config);
+require('fourk-gulp')(gulp, config);
+```
+* The gulp-config.js file is still used and most likely would be committed to the project repo. The local.gulp-config could be used to override config for your machine and should be gitignored.
+* You'll now be able to execute any task in this repo. Run `gulp help` for more info on these tasks.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 /* globals require */
 
-(function () {
-
+module.exports = function(gulp, config) {
   'use strict';
 
   // General
@@ -16,15 +15,6 @@
 
   // icons
   var svgSprite = require('gulp-svg-sprite');
-
-  var localConfig = {};
-
-  try {
-    localConfig = require('./local.gulp-config');
-  }
-  catch (e) {
-    config = _.defaultsDeep(localConfig, config);
-  }
 
   var tasks = {
     compile: [],
@@ -118,4 +108,4 @@
    */
   gulp.task('build', ['imagemin', 'clean', 'scripts', 'styleguide-scripts', 'css', 'icons']);
 
-})();
+};

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = function(gulp, config) {
   'use strict';
 
   // General
-  var gulp = require('gulp-help')(require('gulp'));
+  var gulp = require('gulp-help')(gulp);
   var _ = require('lodash');
   var concat = require('gulp-concat');
   var browserSync = require('browser-sync').create();

--- a/package.json
+++ b/package.json
@@ -1,17 +1,7 @@
 {
-  "name": "fourk",
-  "description": "The source repository to the [SITENAME] site.",
+  "name": "fourk gulp",
+  "description": "A collection of useful gulp tasks.",
   "version": "0.0.1",
-  "private": true,
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:[SITENAME].git"
-  },
-  "scripts": {
-    "aquifer": "aquifer",
-    "start": "gulp clean && gulp compile && gulp theme",
-    "postinstall": "gulp build && find node_modules/ -name \"*.info\" -type f -delete"
-  },
   "devDependencies": {
     "breakpoint-sass": "^2.7.0",
     "browser-sync": "^2.11.0",
@@ -43,7 +33,6 @@
     "node-normalize-scss": "^1.3.1",
     "node-notifier": "^4.6.0",
     "sassdoc": "^2.1.20",
-    "singularitygs": "^1.7.0",
     "sync-exec": "~0.5.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,5 @@
     "node-notifier": "^4.6.0",
     "sassdoc": "^2.1.20",
     "sync-exec": "~0.5.0"
-  },
-  "dependencies": {
-    "aquifer": "aquifer/aquifer#1.0.0-nyun-2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fourk gulp",
+  "name": "fourk-gulp",
   "description": "A collection of useful gulp tasks.",
   "version": "0.0.1",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fourk-gulp",
   "description": "A collection of useful gulp tasks.",
   "version": "0.0.1",
-  "devDependencies": {
+  "dependencies": {
     "breakpoint-sass": "^2.7.0",
     "browser-sync": "^2.11.0",
     "del": "^2.2.0",


### PR DESCRIPTION
## Test
* Inside your project root of your example site we've been hacking on, `npm i --save-dev infiniteluke/fourk-gulp#modularize`
* Wipe out your old gulpfile and change it to:
```
  // General
  var gulp = require('gulp-help')(require('gulp'));
  var _ = require('lodash');
  var config = require('./gulp-config');
  var localConfig = {};

  try {
    localConfig = require('./local.gulp-config');
  }
  catch (e) {}
  config = _.defaultsDeep(localConfig, config);
  require('fourk-gulp')(gulp, config);
```

This will pass gulp and config along to the newly installed tasks.
* Notice the `local.gulp-config` file. The `gulp-config` file is still used and I assume would be committed to the project repo. The `local.gulp-config` could be used to override config for your machine and should be gitignored.
* run `gulp psi` and ensure the tasks runs usual.