### PR TITLE
Make configuration merging happen inside gulp-fourk

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ A collection of useful gulp tasks.
 ```
 const gulp = require('gulp-help')(require('gulp'));
 const _ = require('lodash');
-let config = require('./gulp-config');
 let localConfig = {};
 
+// Attempt to load an optional local configuration file.
 try {
   localConfig = require('./local.gulp-config');
 }
 catch (e) {}
 
-config = _.defaultsDeep(localConfig, config);
-require('fourk-gulp')(gulp, config);
+// Load all gulp tasks.
+require('fourk-gulp')(gulp, localConfig);
 ```
 * The gulp-config.js file is still used and most likely would be committed to the project repo. The local.gulp-config could be used to override config for your machine and should be gitignored.
 * You'll now be able to execute any task in this repo. Run `gulp help` for more info on these tasks.

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ module.exports = function(gulp, config) {
   var _ = require('lodash');
   var concat = require('gulp-concat');
   var browserSync = require('browser-sync').create();
-  var config = require('./gulp-config');
+  var defaultConfig = require('./gulp-config');
+  var config = _.defaultsDeep(defaultConfig, config);
+  
 
   // Image Minification
   var imagemin = require('gulp-imagemin');


### PR DESCRIPTION
This is a cleaner way of doing config. Now you don't need to load `gulp-config.js` manually.